### PR TITLE
fix remaining instances of "rader" typo

### DIFF
--- a/content/compendium/_meta.js
+++ b/content/compendium/_meta.js
@@ -2,7 +2,7 @@ export default{
   gamemodes: 'Gamemodes',
   unlocks: 'Unlocks',
   volforce: 'Volforce',
-  rader: 'Rader',
+  radar: 'Radar',
   customization: 'Customization',
   basicpremcourses: 'Basic and Premium Course, Rivals, Data, Etc.',
   downtime: 'Maintence and Downtime',

--- a/content/compendium/radar.mdx
+++ b/content/compendium/radar.mdx
@@ -1,14 +1,14 @@
 # Radar
 ## Table of Contents
-1. [Intro](/compendium/rader#intro)
-2. [Rader types](/compendium/rader#radar-types)
-    1. [Notes](/compendium/rader#notes)
-    2. [Peak](/compendium/rader#peak)
-    3. [Tsumami](/compendium/rader#tsumami)
-    4. [One hand](/compendium/rader#one-hand)
-    5. [Hand trip](/compendium/rader#hand-trip)
-    6. [Tricky](/compendium/rader#tricky)
-3. [Profile Radar](/compendium/rader#profile-radar)
+1. [Intro](/compendium/radar#intro)
+2. [Radar types](/compendium/radar#radar-types)
+    1. [Notes](/compendium/radar#notes)
+    2. [Peak](/compendium/radar#peak)
+    3. [Tsumami](/compendium/radar#tsumami)
+    4. [One hand](/compendium/radar#one-hand)
+    5. [Hand trip](/compendium/radar#hand-trip)
+    6. [Tricky](/compendium/radar#tricky)
+3. [Profile Radar](/compendium/radar#profile-radar)
 
 ## Intro
 There are currently 2 radars in the game. One on your profile and one for every chart in the game. 


### PR DESCRIPTION
Unfortunately, it turns out it is _not_ a reference to the "NOTES RADER" typo in IIDX 32 Pinky Crush.