### PR TITLE
patch: Replace dead myshkin links with sdvx-song-info webapp

### DIFF
--- a/content/en/setup/konasute.mdx
+++ b/content/en/setup/konasute.mdx
@@ -53,7 +53,7 @@ SDVX made by Konami.
 - [Training Mode](/compendium/game-modes#training-mode) and [Maxxive Rate](/compendium/gauge-options#maxxive-rate) is locked behind an additional paywall of 500 yen per month.
 
 If you want to know what songs are included with the basic course or each song
-pack, you can check [here](https://www.myshkin.io/sdvx/songlist).
+pack, you can check [here](https://sdvx-song-info.web.app/).
 Every couple months, Konami will add new songs to the basic course.
 
 ## Setup
@@ -197,7 +197,7 @@ the game works for you. If you encounter any problems, try to resolve them befor
 ### Purchasing Basic Course
 
 To play Konasute, you have to subscribe to the basic course of the game. This
-comes with around 688 default songs with more being added occasionally. You can check out the default song list [here](https://www.myshkin.io/sdvx/songlist).
+comes with around 688 default songs with more being added occasionally. You can check out the default song list [here](https://sdvx-song-info.web.app/).
 
 The recommended way to purchase the basic course is to use Paseli. You can also link it
 to a credit card if you want, but it's recommended to just use Paseli since you
@@ -243,7 +243,7 @@ a week or so. To know when a sale happens, you can either follow:
 To see and purchase all the song packs head to [the e-amusement
 shop](https://p.eagate.573.jp/gate/p/eamusement/coop/mall.html?fromlist&dt=%2F%E3%82%B3%E3%83%8A%E3%82%B9%E3%83%86%20SOUND%20VOLTEX%2F%E6%A5%BD%E6%9B%B2%E3%83%91%E3%83%83%E3%82%AF%2F).
 Here is where you can see and purchase all the song packs. To know what's in
-each pack, you can head to [this website](https://www.myshkin.io/sdvx/songlist)
+each pack, you can head to [this website](https://sdvx-song-info.web.app/)
 and sort by song pack in the `Availability (PC)` dropdown, or head to
 [here](https://p.eagate.573.jp/game/eacsdvx/vi/music/index.html) and sort with
 the `プレー条件` drop down.
@@ -285,7 +285,7 @@ Now, your new e-Amusement card should be linked to your Konasute data.
 - [voltexes.com guide](https://voltexes.com/setting-up-sound-voltex-konasute-exceed-gear/)
 - [3icecream.com e-amusement set-up](https://3icecream.com/tutorial/check-eamuse)
 - [Offical Sound Voltex Twitter/X](https://twitter.com/SOUNDVOLTEX573)
-- [myshkin.io Konasute songlist](https://www.myshkin.io/sdvx/songlist)
+- [SDVX song info web app by Karen/cosmopolitan093 on discord](https://sdvx-song-info.web.app/)
 - [Offical Konasute Website](https://p.eagate.573.jp/game/eacsdvx/vi/index.html)
 - [Voicemeeter Set-up by Sakif](https://github.com/SakifX9/Rhythm-Game-Optimisations/blob/main/Voicemeeter/How%20to%20setup%20Voicemeeter%20for%20Rhythm%20Games.md)
 - [Konasute Optimisations by Sakif](https://github.com/SakifX9/Rhythm-Game-Optimisations/blob/main/Sound%20Voltex%20コナステ/Sound%20Voltex%20Optimisations.md)


### PR DESCRIPTION
Addresses #88 

This is a proposed diff to fix the issue of dead links on the production `sdvx.org/en/setup/konasute`.

For fuller details of the issue being solved, please refer to the original issue thread linked above.