### PR TITLE
patch: Verbiage changes to reflect UI differences in sdvx-song-info

### DIFF
--- a/content/en/setup/konasute.mdx
+++ b/content/en/setup/konasute.mdx
@@ -244,7 +244,7 @@ To see and purchase all the song packs head to [the e-amusement
 shop](https://p.eagate.573.jp/gate/p/eamusement/coop/mall.html?fromlist&dt=%2F%E3%82%B3%E3%83%8A%E3%82%B9%E3%83%86%20SOUND%20VOLTEX%2F%E6%A5%BD%E6%9B%B2%E3%83%91%E3%83%83%E3%82%AF%2F).
 Here is where you can see and purchase all the song packs. To know what's in
 each pack, you can head to [this website](https://sdvx-song-info.web.app/)
-and sort by song pack in the `Availability (PC)` dropdown, or head to
+and filter by song pack in the `Unlock Condition (Konasute)` dropdown, or head to
 [here](https://p.eagate.573.jp/game/eacsdvx/vi/music/index.html) and sort with
 the `プレー条件` drop down.
 


### PR DESCRIPTION
Small follow up PR to #89 

Basically changing the language around how to filter to specific song packs.

The new website does not have an `Availability (PC)` dropdown, it instead offers this through a `Unlock Condition (Konasute)` dropdown:

<img width="1413" height="563" alt="Screenshot 2026-04-10 at 10 11 00 PM" src="https://github.com/user-attachments/assets/db3b45fe-9c20-4a2e-926d-6b625e823f4e" />
