### PR TITLE
patch: Update premium pass links and premium pass info

### DIFF
--- a/content/en/compendium/basic-premium-courses.mdx
+++ b/content/en/compendium/basic-premium-courses.mdx
@@ -63,7 +63,7 @@ Buying this pass allows for you to use
 - [Maxxive Rate](/compendium/gauge-options#maxxive-rate)
 - [Training Mode](/compendium/game-modes#training-mode)
 - 3x Blaster Gauge Boost
-- Blaster Gate songs will unlock after one play/attempt bypasses the normal 20 play pity unlock mechanic)
+- Blaster Gate songs will unlock after one play/attempt. Notably, this bypasses the normally enforced 20 play/pity unlock mechanic.
 
 ## Blaster Pass
 Blaster Pass helps unlocking songs faster. Blaster pass is 24hrs from when you purchase it. During this 24hrs, you acquire blaster gauge faster. It also helps for [Variant Gate](/compendium/unlock-systems#variant-gate) unlocks. To learn more, see [Variant Gate](/compendium/unlock-systems#variant-gate).

--- a/content/en/compendium/basic-premium-courses.mdx
+++ b/content/en/compendium/basic-premium-courses.mdx
@@ -57,7 +57,7 @@ download. You can choose what format you would like to download it.
 If you have the e-amusement app, you can also view your data [there](https://eam.573.jp/app/web/howto/?page=sdvx_score_tool.html) if you have the premium course. This will also give you a bit more information about your data. 
 
 ## Premium Pass
-To access [Training Mode](/compendium/game-modes#training-mode) and [Maxxive Rate](/compendium/gauge-options#maxxive-rate) you need the Premium Pass. The Premium Pass is either 500 yen a month or 2500 yen or 180 days. The 180 days will save you a month, or 500 yen. You can buy this pass [here](https://p.eagate.573.jp/gate/p/eamusement/coop/mall.html?category=45&fromlist).
+To access [Training Mode](/compendium/game-modes#training-mode) and [Maxxive Rate](/compendium/gauge-options#maxxive-rate) you need the Premium Pass. The Premium Pass is either 500 yen a month or 2500 yen or 180 days. The 180 days will save you a month, or 500 yen. You can buy this pass [here](https://p.eagate.573.jp/gate/p/eamusement/coop/mall.html?category=41&fromlist) (konasute category) or [here](https://p.eagate.573.jp/gate/p/eamusement/coop/mall.html?fromlist&dt=%2F%E3%82%B3%E3%83%8A%E3%82%B9%E3%83%86%20SOUND%20VOLTEX%2F%E3%83%97%E3%83%AC%E3%83%9F%E3%82%A2%E3%83%A0%E3%83%91%E3%82%B9%2F) (direct link to konasute premium pass subcategory).
 
 Buying this pass allows for you to use
 - [Maxxive Rate](/compendium/gauge-options#maxxive-rate)

--- a/content/en/compendium/basic-premium-courses.mdx
+++ b/content/en/compendium/basic-premium-courses.mdx
@@ -63,6 +63,7 @@ Buying this pass allows for you to use
 - [Maxxive Rate](/compendium/gauge-options#maxxive-rate)
 - [Training Mode](/compendium/game-modes#training-mode)
 - 3x Blaster Gauge Boost
+- Blaster Gate songs will unlock after one play/attempt bypasses the normal 20 play pity unlock mechanic)
 
 ## Blaster Pass
 Blaster Pass helps unlocking songs faster. Blaster pass is 24hrs from when you purchase it. During this 24hrs, you acquire blaster gauge faster. It also helps for [Variant Gate](/compendium/unlock-systems#variant-gate) unlocks. To learn more, see [Variant Gate](/compendium/unlock-systems#variant-gate).

--- a/content/en/setup/konasute.mdx
+++ b/content/en/setup/konasute.mdx
@@ -249,7 +249,7 @@ and filter by song pack in the `Unlock Condition (Konasute)` dropdown, or head t
 the `プレー条件` drop down.
 
 ### Premium Pass 
-To access [Training Mode](/compendium/game-modes#training-mode) and [Maxxive Rate](/compendium/gauge-options#maxxive-rate) you need the Premium Pass. The Premium Pass is either 500 yen a month or 2500 yen or 180 days. The 180 days will save you a month, or 500 yen. You can buy this pass [here](https://p.eagate.573.jp/gate/p/eamusement/coop/mall.html?category=45&fromlist).
+To access [Training Mode](/compendium/game-modes#training-mode) and [Maxxive Rate](/compendium/gauge-options#maxxive-rate) you need the Premium Pass. The Premium Pass is either 500 yen a month or 2500 yen or 180 days. The 180 days will save you a month, or 500 yen. You can buy this pass [here](https://p.eagate.573.jp/gate/p/eamusement/coop/mall.html?category=41&fromlist) (konasute category) or [here](https://p.eagate.573.jp/gate/p/eamusement/coop/mall.html?fromlist&dt=%2F%E3%82%B3%E3%83%8A%E3%82%B9%E3%83%86%20SOUND%20VOLTEX%2F%E3%83%97%E3%83%AC%E3%83%9F%E3%82%A2%E3%83%A0%E3%83%91%E3%82%B9%2F) (direct link to konasute premium pass subcategory).
 
 Buying this pass allows for you to use
 - [Maxxive Rate](/compendium/gauge-options#maxxive-rate)

--- a/content/en/setup/konasute.mdx
+++ b/content/en/setup/konasute.mdx
@@ -255,6 +255,7 @@ Buying this pass allows for you to use
 - [Maxxive Rate](/compendium/gauge-options#maxxive-rate)
 - [Training Mode](/compendium/game-modes#training-mode)
 - 3x Blaster Gauge Boost
+- Blaster Gate songs will unlock after one play/attempt. Notably, this bypasses the normally enforced 20 play/pity unlock mechanic.
 
 
 ## Linking Arcade and Konasute Data


### PR DESCRIPTION
**Motivation for this PR**

By chance I was recently looking into/setting up konasute premium pass for myself, and noticed the recently added links on the wiki go to `https://p.eagate.573.jp/gate/p/eamusement/coop/mall.html?category=45&fromlist`. 

Navigating to this link works basically like this:
- Go to `https://p.eagate.573.jp/gate/p/eamusement/coop/mall.html?category=45&fromlist` (category 45)
- HTML page loads and executes `https://p.eagate.573.jp/gate/p/eamusement/coop/js/mall.js?20251119`
- This JS file then does a history.replaceState to `https://p.eagate.573.jp/gate/p/eamusement/coop/mall.html?fromlist&dt=%2F%E3%82%B3%E3%83%8A%E3%82%B9%E3%83%86%20SOUND%20VOLTEX%2F%E6%A5%BD%E6%9B%B2%E3%83%91%E3%83%83%E3%82%AF%2F` (no new page fetch happens, this is just translating the original `?category=` url to a `?dt=` url)

Main thing to note here, is that the `category=45` link goes directly to the konasute -> music pack subcategory on the eamuse shop. Normally this would be fine, however, the premium passes intentionally do not show up on this page. This page is **only** for the individual music pack listings. The periodic music pack sets/discounts are special, and get their own subcategory. What this all means, is that it's not possible to buy the premium pass from the current link on the wiki.

**Solution**

I did some digging to see if there was a similar `category=X` mapping that goes directly to the existing konasute -> premium pass subcategory. Unfortunately I could not find one. This leaves two other options for linking users to the page for buying the konasute premium pass:
- Link directly to the premium pass subcategory via its `dt=X` url. That URL is `https://p.eagate.573.jp/gate/p/eamusement/coop/mall.html?fromlist&dt=%2F%E3%82%B3%E3%83%8A%E3%82%B9%E3%83%86%20SOUND%20VOLTEX%2F%E3%83%97%E3%83%AC%E3%83%9F%E3%82%A2%E3%83%A0%E3%83%91%E3%82%B9%2F`.
- Link to the broad konasute top-level category. This category includes EVERYTHING konasute on the eamuse shop - premium pass, normal song pack listings, discount/sale song pack set listings. This URL is category 41, aka `https://p.eagate.573.jp/gate/p/eamusement/coop/mall.html?category=41&fromlist` -> `https://p.eagate.573.jp/gate/p/eamusement/coop/mall.html?fromlist&dt=%2F%E3%82%B3%E3%83%8A%E3%82%B9%E3%83%86%20SOUND%20VOLTEX%2F%E3%83%81%E3%82%B1%E3%83%83%E3%83%88%2F`.

**Changes**

- In this PR, I changed the docs to provide both of these links (redundancy in case the eamuse shop changes to break any of them in the future)
- I also added a note to mention that konasute premium pass bypasses the normal 20 play/attempt restriction for unlocking blaster gate songs. I figured it was worth adding because I was not aware of that fact prior, and it makes the pass more appealing to those looking to do blaster gate unlocks in bulk.

**Pages affected**
- Affects content on `https://www.sdvx.org/en/compendium/basic-premium-courses#premium-pass`
- Affects content on `https://www.sdvx.org/en/setup/konasute#premium-pass`